### PR TITLE
Updated the .ovsschema to work with current ovsdb

### DIFF
--- a/_posts/2014-09-21-ovsdb.md
+++ b/_posts/2014-09-21-ovsdb.md
@@ -82,34 +82,40 @@ focus on the part of the schema definition that talks about the tables.
 
 {% highlight json linenos %}
 {
-    "List": {
-        "columns": {
-            "name": {
-                "type": "string"
-            },
-            "items": {
-                "type": {
-                    "key": {
-                        "type": "uuid",
-                        "refTable": "Item"
-                    },
-                    "min": 0,
-                    "max": "unlimited"
+    "name": "todo",
+    "version": "1.0.0",
+    "tables": {
+        "List": {
+            "columns": {
+                "name": {
+                    "type": "string"
+                },
+                "items": {
+                    "type": {
+                        "key": {
+                            "type": "uuid",
+                            "refTable": "Item"
+                        },
+                        "min": 0,
+                        "max": "unlimited"
+                    }
                 }
-            }
-        },
-        "isRoot": true,
-        "indexes": [
-            ["name"]
-        ]
-    },
-    "Item": {
-        "columns": {
-            "status": {
-                "type": "string"
             },
-            "description": {
-                "type": "string"
+            "isRoot": true,
+            "indexes": [
+                [
+                    "name"
+                ]
+            ]
+        },
+        "Item": {
+            "columns": {
+                "status": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                }
             }
         }
     }


### PR DESCRIPTION
The requirements for the ovsschema files have changed, and they now require a name, a version and the tables are defined in a table element. This edit updates the example in the post so that it works with current versions of ovsdb.